### PR TITLE
Fixed memory leaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ var Smooth = window.Smooth = module.exports = function(opt) {
 
 	opt = opt || {}
 
-	this.rAF;
-	
+	this.rAF = undefined;
+
 	this.pos = { targetX: 0, targetY: 0, currentX: 0, currentY: 0 };
 	
 	this.direction = opt.direction || 'vertical';


### PR DESCRIPTION
As it is, the `destroy` methods doesn't clear anything because of the `bind(this)` memory leak ([a bit more info here](http://stackoverflow.com/a/15819293).

This PR adds some code to cache all bounds methods so the `destroy` works properly!
