### PR TITLE
Fix undefined variable (this.direction -> this.vars.direction)

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ class Smooth {
     
     getTransform(value) {
         
-        return this.direction === 'vertical' ? 'translate3d(0,' + value + 'px,0)' : 'translate3d(' + value + 'px,0,0)'
+        return this.vars.direction === 'vertical' ? 'translate3d(0,' + value + 'px,0)' : 'translate3d(' + value + 'px,0,0)'
     }
     
     on() {


### PR DESCRIPTION
Hi,

`this.direction` is not defined for `getTransform()` method
