### PR TITLE
Fix undefined variable (this.direction -> this.vars.direction) for calc() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ class Smooth {
     
     calc(e) {
         
-        const delta = this.direction == 'horizontal' ? e.deltaX : e.deltaY
+        const delta = this.vars.direction == 'horizontal' ? e.deltaX : e.deltaY
         
         this.vars.target += delta * -1
         this.vars.target = Math.max(0, Math.min(this.vars.target, this.vars.bounding))


### PR DESCRIPTION
Hi,

`this.direction` is not defined for `calc()` method
