### PR TITLE
[fixes] - FF + IE & [improvement] - destroy() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Fork of https://github.com/baptistebriel/smooth-scrolling
+
+Original doc:
+
 # smooth
 
 Smooth is a small JavaScript module based on [VirtualScroll](http://www.everyday3d.com/blog/index.php/2014/08/18/smooth-scrolling-with-virtualscroll/) to create smooth scrolling and parallax effects on scroll.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# Fork of https://github.com/baptistebriel/smooth-scrolling
-
-Original doc:
-
 # smooth
 
 Smooth is a small JavaScript module based on [VirtualScroll](http://www.everyday3d.com/blog/index.php/2014/08/18/smooth-scrolling-with-virtualscroll/) to create smooth scrolling and parallax effects on scroll.

--- a/index.js
+++ b/index.js
@@ -17,9 +17,9 @@ export default class Smooth {
 
         // It seems that under heavy load, Firefox will still call the RAF callback even though the RAF has been canceled
         // To prevent that we set a flag to prevent any callback to be executed when RAF is removed
-        this.isRAFCanceled = false;
+        this.isRAFCanceled = false
         
-        const constructorName = this.constructor.name ? this.constructor.name : 'Smooth';
+        const constructorName = this.constructor.name ? this.constructor.name : 'Smooth'
         this.extends = constructorName != 'Smooth'
         
         this.vars = {
@@ -135,7 +135,7 @@ export default class Smooth {
     
     run() {
         if (this.isRAFCanceled) {
-            return;
+            return
         }
 
         this.vars.current += (this.vars.target - this.vars.current) * this.vars.ease
@@ -165,7 +165,7 @@ export default class Smooth {
     
     on(requestAnimationFrame = true) {
         if (this.isRAFCanceled) {
-            this.isRAFCanceled = false;
+            this.isRAFCanceled = false
         }
 
         const node = this.dom.listener === document.body ? window : this.dom.listener
@@ -190,7 +190,7 @@ export default class Smooth {
     }
     
     cancelAnimationFrame() {
-        this.isRAFCanceled = true;
+        this.isRAFCanceled = true
         cancelAnimationFrame(this.rAF)
     }
     
@@ -333,6 +333,7 @@ export default class Smooth {
         } 
         
         this.vars.direction === 'vertical' ? classes.remove(this.dom.listener, 'y-scroll') : classes.remove(this.dom.listener, 'x-scroll')
+        this.vars.current = 0
         
         this.vs && (this.vs.destroy(), this.vs = null)
         

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ export default class Smooth {
         this.prefix = prefix('transform')
         this.rAF = undefined
         
-        this.extends = this.constructor.name != 'Smooth'
+        const constructorName = this.constructor.name ? this.constructor.name : 'Smooth';
+        this.extends = constructorName != 'Smooth'
         
         this.vars = {
             direction: this.options.direction || 'vertical',
@@ -47,7 +48,7 @@ export default class Smooth {
                     clicked: false,
                     x: 0
                 },
-                el: create({ selector: 'div', styles: `vs-scrollbar vs-${this.vars.direction} vs-scrollbar-${this.constructor.name.toLowerCase()}` }),
+                el: create({ selector: 'div', styles: `vs-scrollbar vs-${this.vars.direction} vs-scrollbar-${constructorName.toLowerCase()}` }),
                 drag: {
                     el: create({ selector: 'div', styles: 'vs-scrolldrag' }),
                     delta: 0,

--- a/smooth-scrolling.js
+++ b/smooth-scrolling.js
@@ -415,6 +415,7 @@ var Smooth = function () {
             }
 
             this.vars.direction === 'vertical' ? _domClasses2.default.remove(this.dom.listener, 'y-scroll') : _domClasses2.default.remove(this.dom.listener, 'x-scroll');
+            this.vars.current = 0;
 
             this.vs && (this.vs.destroy(), this.vs = null);
 

--- a/smooth-scrolling.js
+++ b/smooth-scrolling.js
@@ -44,7 +44,8 @@ var Smooth = function () {
         this.prefix = (0, _prefix2.default)('transform');
         this.rAF = undefined;
 
-        this.extends = this.constructor.name != 'Smooth';
+        var constructorName = this.constructor.name ? this.constructor.name : 'Smooth';
+        this.extends = constructorName != 'Smooth';
 
         this.vars = {
             direction: this.options.direction || 'vertical',
@@ -76,7 +77,7 @@ var Smooth = function () {
                     clicked: false,
                     x: 0
                 },
-                el: (0, _domCreateElement2.default)({ selector: 'div', styles: 'vs-scrollbar vs-' + this.vars.direction + ' vs-scrollbar-' + this.constructor.name.toLowerCase() }),
+                el: (0, _domCreateElement2.default)({ selector: 'div', styles: 'vs-scrollbar vs-' + this.vars.direction + ' vs-scrollbar-' + constructorName.toLowerCase() }),
                 drag: {
                     el: (0, _domCreateElement2.default)({ selector: 'div', styles: 'vs-scrolldrag' }),
                     delta: 0,

--- a/smooth-scrolling.js
+++ b/smooth-scrolling.js
@@ -44,6 +44,10 @@ var Smooth = function () {
         this.prefix = (0, _prefix2.default)('transform');
         this.rAF = undefined;
 
+        // It seems that under heavy load, Firefox will still call the RAF callback even though the RAF has been canceled
+        // To prevent that we set a flag to prevent any callback to be executed when RAF is removed
+        this.isRAFCanceled = false;
+
         var constructorName = this.constructor.name ? this.constructor.name : 'Smooth';
         this.extends = constructorName != 'Smooth';
 
@@ -171,6 +175,9 @@ var Smooth = function () {
     }, {
         key: 'run',
         value: function run() {
+            if (this.isRAFCanceled) {
+                return;
+            }
 
             this.vars.current += (this.vars.target - this.vars.current) * this.vars.ease;
             this.vars.current < .1 && (this.vars.current = 0);
@@ -202,6 +209,9 @@ var Smooth = function () {
         value: function on() {
             var requestAnimationFrame = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
 
+            if (this.isRAFCanceled) {
+                this.isRAFCanceled = false;
+            }
 
             var node = this.dom.listener === document.body ? window : this.dom.listener;
 
@@ -250,7 +260,7 @@ var Smooth = function () {
 
             return cancelAnimationFrame;
         }(function () {
-
+            this.isRAFCanceled = true;
             cancelAnimationFrame(this.rAF);
         })
     }, {


### PR DESCRIPTION
On IE < Edge, this.constructor.name doesn't exist. A fix would be to default that value to 'Smooth'. One side effect I noted is that on IE11 it will break the extend.

On Firefox it seems that when canceling a RAF, old entries in the callbacks list are still being executed rather than being destroyed. To prevent this, we can set a flag that prevents any call to the RAF's callback function when the RAF is canceled.

Lastly, when calling destroy() the current scroll value is not reset to 0, which can cause some issues where elements rely on that value (like animating an image based on the scroll in a RAF) even though the scroll is destroyed. Setting the vars.current to 0 in the destroy() would allow for a proper removal of the scroll.

🍻 