### PR TITLE
Check if 'extends' has been explicitly set as an option

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ export default class Smooth {
         this.isRAFCanceled = false
         
         const constructorName = this.constructor.name ? this.constructor.name : 'Smooth'
-        this.extends = constructorName != 'Smooth'
+        this.extends = typeof opt.extends === 'undefined' ? constructorName != 'Smooth' : opt.extends
         
         this.callback = this.options.callback || null
         


### PR DESCRIPTION
Hi @baptistebriel

I ran into an issue using this module in my webpack project with uglify because `this.extends` is set by checking if the constructor name is `Smooth`. In my situation, uglify was renaming the classname during the minification process which would mean the `this.extends` would be set to true, breaking the unextended class.

I think only relying on the class name isn't always reliable, so I think it would be helpful to provide the option to explicitly set it.

It also seems that in some of the demos, there's already an extends parameter, so this follows suit 🙂