### PR TITLE
Fixes webpack production build issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ export default class Smooth {
     // To prevent that we set a flag to prevent any callback to be executed when RAF is removed
     this.isRAFCanceled = false
     const constructorName = this.constructor.name ? this.constructor.name : 'Smooth'
-    this.extends = typeof opt.extends === 'undefined' ? constructorName != 'Smooth' : opt.extends
+    this.extends = typeof opt.extends === 'undefined' ? this.constructor !== Smooth : opt.extends
     this.callback = this.options.callback || null
     this.vars = {
       direction: this.options.direction || 'vertical',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smooth-scrolling",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "description": "Smooth is a small JavaScript module based on VirtualScroll to create smooth scrolling and parallax effects on scroll.",
   "main": "index.js",
   "dependencies": {

--- a/smooth-scrolling.js
+++ b/smooth-scrolling.js
@@ -45,7 +45,7 @@ var Smooth = function () {
     // To prevent that we set a flag to prevent any callback to be executed when RAF is removed
     this.isRAFCanceled = false;
     var constructorName = this.constructor.name ? this.constructor.name : 'Smooth';
-    this.extends = typeof opt.extends === 'undefined' ? constructorName != 'Smooth' : opt.extends;
+    this.extends = typeof opt.extends === 'undefined' ? this.constructor !== Smooth : opt.extends;
     this.callback = this.options.callback || null;
     this.vars = {
       direction: this.options.direction || 'vertical',


### PR DESCRIPTION
Instead of relaying on the class name which can result in various problems, it is better to test if the constructor equals the class. This also prevents webpack from mangling the class name and break the script in production mode.