### PR TITLE
Add virtual-scroll useKeyboard option support 

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ export default class Smooth {
       touchMultiplier: this.options.vs && this.options.vs.touchMultiplier || 1.5,
       firefoxMultiplier: this.options.vs && this.options.vs.firefoxMultiplier || 30,
       preventTouch: this.options.vs && this.options.vs.hasOwnProperty('preventTouch') ? this.options.vs.preventTouch : true,
+      useKeyboard: this.options.vs && this.options.vs.hasOwnProperty('useKeyboard') ? this.options.vs.useKeyboard : true,
     })
     this.dom = {
       listener: this.options.listener || document.body,

--- a/index.js
+++ b/index.js
@@ -32,11 +32,11 @@ export default class Smooth {
       ticking: false
     }
     this.vs = this.vars.native ? null : new vs({
-      limitInertia: this.options.vs && this.options.vs.limitInertia || false,
+      limitInertia: this.options.vs && this.options.vs.hasOwnProperty('limitInertia') ? this.options.vs.limitInertia : false,
       mouseMultiplier: this.options.vs && this.options.vs.mouseMultiplier || 1,
       touchMultiplier: this.options.vs && this.options.vs.touchMultiplier || 1.5,
       firefoxMultiplier: this.options.vs && this.options.vs.firefoxMultiplier || 30,
-      preventTouch: this.options.vs && this.options.vs.preventTouch || true
+      preventTouch: this.options.vs && this.options.vs.hasOwnProperty('preventTouch') ? this.options.vs.preventTouch : true,
     })
     this.dom = {
       listener: this.options.listener || document.body,

--- a/smooth-scrolling.js
+++ b/smooth-scrolling.js
@@ -57,11 +57,12 @@ function () {
       ticking: false
     };
     this.vs = this.vars["native"] ? null : new _virtualScroll["default"]({
-      limitInertia: this.options.vs && this.options.vs.limitInertia || false,
+      limitInertia: this.options.vs && this.options.vs.hasOwnProperty('limitInertia') ? this.options.vs.limitInertia : false,
       mouseMultiplier: this.options.vs && this.options.vs.mouseMultiplier || 1,
       touchMultiplier: this.options.vs && this.options.vs.touchMultiplier || 1.5,
       firefoxMultiplier: this.options.vs && this.options.vs.firefoxMultiplier || 30,
-      preventTouch: this.options.vs && this.options.vs.preventTouch || true
+      preventTouch: this.options.vs && this.options.vs.hasOwnProperty('preventTouch') ? this.options.vs.preventTouch : true,
+      useKeyboard: this.options.vs && this.options.vs.hasOwnProperty('useKeyboard') ? this.options.vs.useKeyboard : true
     });
     this.dom = {
       listener: this.options.listener || document.body,


### PR DESCRIPTION
This adds support for the `useKeyboard` option: https://github.com/ayamflow/virtual-scroll/blob/master/src/index.js#L37.  

Also, it fixes issues where a user might set a boolean option to `false` explicitly but, instead, the default value would be use.  Like right now, if `preventTouch` is `false` like:

```js
new SmoothCustom({
  vs: { preventTouch: false }
})
```

... It will get re-set to `true` via:

```js
this.options.vs.preventTouch || true
```